### PR TITLE
feat: constrain collections column width (fixes #11)

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -447,8 +447,11 @@ func (m modelState) View() string {
 			maxMargin = len(e.MarginKey)
 		}
 	}
-	if maxMargin < 2 {
-		maxMargin = 2 // Minimal width for visual separation
+	if maxMargin > 12 {
+		maxMargin = 12
+	}
+	if maxMargin < 1 {
+		maxMargin = 1 // Minimal width for visual separation
 	}
 
 	var contentLines []string
@@ -502,7 +505,11 @@ func (m modelState) View() string {
 
 			// Dynamic MarginKey
 			marginStr := ""
-			paddedMK := fmt.Sprintf("%-*s", maxMargin, entry.MarginKey)
+			displayMK := entry.MarginKey
+			if len(displayMK) > maxMargin {
+				displayMK = displayMK[:maxMargin-1] + "…"
+			}
+			paddedMK := fmt.Sprintf("%-*s", maxMargin, displayMK)
 			if entry.MarginKey != "" {
 				marginStr = MarginKeyStyle.Render(paddedMK) + " "
 			} else {


### PR DESCRIPTION
This PR constrains the collections column width to a maximum of 12 characters and reduces the default gap when no collections are present to 2 characters, as requested. Ellipses are added for truncated collection names.